### PR TITLE
Refactor cities

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -5,19 +5,7 @@ class WelcomeController < ApplicationController
   skip_after_action :verify_policy_scoped
 
   def index
-    @markers = Gmaps4rails.build_markers(
-      City.preload(end_of_tracks: [:competition, ranks: [:user]])
-          .on_map
-          .distinct(:locality)
-    ) do |city, marker|
-      marker.lat city.lat
-      marker.lng city.lng
-      marker.picture("url" => ActionController::Base.helpers.asset_path("marker.svg"),
-                     "width" =>  32,
-                     "height" => 32)
-      marker.infowindow render_to_string(partial: "/welcome/map_box",
-                                         locals: { city: city })
-    end
+    @markers = Marker.for_all_relevant_cities
 
     if user_signed_in?
       render "dashboard"

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,4 +1,12 @@
 # frozen_string_literal: true
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def self._exists(scope)
+    "EXISTS(#{scope.select(1).to_sql})"
+  end
+
+  def self._not_exists(scope)
+    "NOT #{_exists(scope)}"
+  end
 end

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -22,6 +22,16 @@
 #
 
 class City < ApplicationRecord
+  scope :on_map, lambda {
+    where(_exists(
+            Competition.finished.joins(:tracks)
+                       .where("competitions.start_city_id = cities.id OR "\
+                              "competitions.end_city_id = cities.id OR "\
+                              "tracks.start_city_id = cities.id OR "\
+                              "tracks.end_city_id = cities.id")
+    ))
+  }
+
   has_many :start_of_competitions, class_name: "Competition", foreign_key: "start_city_id"
   has_many :end_of_competitions, class_name: "Competition", foreign_key: "end_city_id"
 
@@ -36,34 +46,5 @@ class City < ApplicationRecord
 
   def competition
     start_of_competitions.first
-  end
-
-  def self.on_map
-    fc1 = joins(:start_of_competitions)
-          .merge(Competition.finished)
-          .ids
-
-    fc2 = joins(:end_of_competitions)
-          .merge(Competition.finished)
-          .ids
-
-    fc3 = joins(:start_of_track_competitions)
-          .merge(Competition.finished)
-          .ids
-
-    fc4 = joins(:end_of_track_competitions)
-          .merge(Competition.finished)
-          .ids
-
-    where(id: fc1 | fc2 | fc3 | fc4)
-  end
-
-  def self.nowhere
-    c1 = joins(:start_of_competitions).ids
-    c2 = joins(:end_of_competitions).ids
-    c3 = joins(:start_of_tracks).ids
-    c4 = joins(:end_of_tracks).ids
-
-    City.where.not(id: c1 | c2 | c3 | c4)
   end
 end

--- a/app/models/marker.rb
+++ b/app/models/marker.rb
@@ -1,8 +1,7 @@
+# frozen_string_literal: true
 class Marker
   def self.for_all_relevant_cities
-    on_cities(City.preload(end_of_tracks: [:competition, ranks: [:user]])
-                  .on_map
-                  .distinct(:locality))
+    on_cities(City.on_map.preload(end_of_tracks: [:competition, ranks: [:user]]))
   end
 
   def self.on_cities(cities)

--- a/app/models/marker.rb
+++ b/app/models/marker.rb
@@ -1,0 +1,19 @@
+class Marker
+  def self.for_all_relevant_cities
+    on_cities(City.preload(end_of_tracks: [:competition, ranks: [:user]])
+                  .on_map
+                  .distinct(:locality))
+  end
+
+  def self.on_cities(cities)
+    Gmaps4rails.build_markers(cities) do |city, marker|
+      marker.lat city.lat
+      marker.lng city.lng
+      marker.picture("url" => ActionController::Base.helpers.asset_path("marker.svg"),
+                     "width" =>  32,
+                     "height" => 32)
+      marker.infowindow ApplicationController.render(partial: "/welcome/map_box",
+                                                     locals: { city: city })
+    end
+  end
+end

--- a/app/views/welcome/_map_box.html.erb
+++ b/app/views/welcome/_map_box.html.erb
@@ -7,7 +7,7 @@
   <% city.end_of_tracks.joins(:competition).merge(Competition.finished).each do |track| %>
     <%= link_to track.competition, track.competition %>
     <div>
-      <span class="medals-small"><i class="icomoon icon-medal"></i></span> <%= track.ranks.where(result: 1).map{ |r| r.user.first_name if r }.join(' & ') %>
+      <span class="medals-small"><i class="icomoon icon-medal"></i></span> <%= track.ranks.select { |r| r.result == 1 }.map{ |r| r.user.first_name if r }.join(' & ') %>
     </div>
   <% end %>
 

--- a/db/migrate/20160619185646_clean_city_model.rb
+++ b/db/migrate/20160619185646_clean_city_model.rb
@@ -1,6 +1,11 @@
 class CleanCityModel < ActiveRecord::Migration
   def change
-    City.nowhere.each do |c|
+    c1 = City.joins(:start_of_competitions).ids
+    c2 = City.joins(:end_of_competitions).ids
+    c3 = City.joins(:start_of_tracks).ids
+    c4 = City.joins(:end_of_tracks).ids
+
+    City.where.not(id: c1 | c2 | c3 | c4).each do |c|
       c.destroy
     end
 

--- a/spec/models/city_spec.rb
+++ b/spec/models/city_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: cities
+#
+#  id                                :integer          not null, primary key
+#  name                              :string
+#  street_number                     :string
+#  route                             :string
+#  locality                          :string
+#  administrative_area_level_2       :string
+#  administrative_area_level_1       :string
+#  administrative_area_level_1_short :string
+#  country                           :string
+#  country_short                     :string
+#  postal_code                       :string
+#  lat                               :float
+#  lng                               :float
+#  created_at                        :datetime         not null
+#  updated_at                        :datetime         not null
+#  picture                           :string
+#
+
+require "rails_helper"
+
+RSpec.describe City, type: :model do
+  describe "scopes" do
+    before(:each) do
+      paris = FactoryGirl.create(:city, name: "Paris")
+      belgrade = FactoryGirl.create(:city, name: "Belgrade")
+      istanbul = FactoryGirl.create(:city, name: "Istanbul")
+      sofia = FactoryGirl.create(:city, name: "Sofia")
+      berlin = FactoryGirl.create(:city, name: "Berlin")
+      bucharest = FactoryGirl.create(:city, name: "Bucharest")
+
+      # finished
+      FactoryGirl.create(
+        :competition, published: true, start_city: paris, end_city: istanbul,
+                      author: FactoryGirl.create(:user),
+                      tracks: [
+                        Track.new(start_city: paris, end_city: belgrade),
+                        Track.new(start_city: belgrade, end_city: sofia)
+                      ]
+      )
+
+      # unfinished
+      FactoryGirl.create(
+        :competition, finished: false, start_city: berlin, end_city: bucharest,
+                      author: FactoryGirl.create(:user),
+                      tracks: [
+                        Track.new(start_city: berlin, end_city: bucharest)
+                      ]
+      )
+    end
+
+    it "scopes on_map correctly" do
+      expect(City.on_map.pluck(:name))
+        .to contain_exactly("Paris", "Belgrade", "Sofia", "Istanbul")
+    end
+  end
+end


### PR DESCRIPTION
- map with all cities (homepage): push marker logic into it's own model. It requires to use `ApplicationController.render` within a model, which isn't great. But I think it is still better than too much logic in the controller
- `City.on_map` was doing 4 queries, reduce to only one
- `City.nowhere` was used in an old migration, put logic there and remove from model
- In city map_box (map), avoid one query for rank.